### PR TITLE
Wrap the checbox input with a label tag

### DIFF
--- a/CheckBoxList.Mvc/Html/CheckBoxListExtensions.cs
+++ b/CheckBoxList.Mvc/Html/CheckBoxListExtensions.cs
@@ -154,10 +154,12 @@ namespace CheckBoxList.Mvc.Html
 
                 var sb = new StringBuilder();
                 sb.AppendLine("<div>");
+                sb.AppendLine("<label>");
                 sb.AppendLine(checkbox.ToHtmlString());
-                sb.AppendLine(text.ToHtmlString());
-                sb.AppendLine(value.ToHtmlString());
                 sb.AppendLine(HttpUtility.HtmlEncode(item.Text));
+                sb.AppendLine("</label>");
+                sb.AppendLine(text.ToHtmlString());
+                sb.AppendLine(value.ToHtmlString());                
                 sb.AppendLine("</div>");
 
                 listItemBuilder.AppendLine(sb.ToString());


### PR DESCRIPTION
When you wrap the checkbox with a label tag then the user will not need to press only the small square button to check the element. The user will be able to change the checkbox status even by clicking on its text.

Regards...
